### PR TITLE
create a separate method to write to existing nwbfile

### DIFF
--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -163,7 +163,7 @@ def write_subject_to_nwb(nwbfile, h5file, individual_name, config_file):
     nwbfile: pynwb.NWBFile
         nwbfile with pes written in the behavior module
     """
-    scorer, df, video, paf_graph, timestamps, _ = _get_pes_args(h5file, individual_name, config_file)
+    scorer, df, video, paf_graph, timestamps, _ = _get_pes_args(config_file, h5file, individual_name)
     df_animal = df.groupby(level="individuals", axis=1).get_group(individual_name)
     return _write_pes_to_nwbfile(nwbfile, individual_name, df_animal, scorer, video, paf_graph, timestamps)
 

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -51,14 +51,11 @@ def _ensure_individuals_in_header(df, dummy_name):
     return df
 
 
-def _get_pes_args(h5file, individual_name, config_file=None, config_dict=None):
+def _get_pes_args(h5file, individual_name, config_file):
     if "DLC" not in h5file or not h5file.endswith(".h5"):
         raise IOError("The file passed in is not a DeepLabCut h5 data file.")
 
-    if config_file is not None:
-        cfg = auxiliaryfunctions.read_config(config_file)
-    else:
-        cfg = config_dict
+    cfg = auxiliaryfunctions.read_config(config_file)
 
     vidname, scorer = os.path.split(h5file)[-1].split("DLC")
     scorer = "DLC" + os.path.splitext(scorer)[0]
@@ -143,7 +140,7 @@ def _write_pes_to_nwbfile(nwbfile, animal, df_animal, scorer, video, paf_graph, 
     return nwbfile
 
 
-def write_subject_to_nwb(nwbfile, h5file, individual_name, config_file=None, config_dict=None):
+def write_subject_to_nwb(nwbfile, h5file, individual_name, config_file):
     """
     Given, subject name, write h5file to an existing nwbfile.
 
@@ -166,9 +163,7 @@ def write_subject_to_nwb(nwbfile, h5file, individual_name, config_file=None, con
     nwbfile: pynwb.NWBFile
         nwbfile with pes written in the behavior module
     """
-    assert config_file is not None or config_dict is not None, "provide one of config_file or config_dict"
-    scorer, df, video, paf_graph, timestamps, cfg = _get_pes_args(h5file, individual_name,
-                                                                  config_file=config_file, config_dict=config_dict)
+    scorer, df, video, paf_graph, timestamps, _ = _get_pes_args(h5file, individual_name, config_file)
     df_animal = df.groupby(level="individuals", axis=1).get_group(individual_name)
     return _write_pes_to_nwbfile(nwbfile, individual_name, df_animal, scorer, video, paf_graph, timestamps)
 

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -51,7 +51,7 @@ def _ensure_individuals_in_header(df, dummy_name):
     return df
 
 
-def _get_pes_args(h5file, individual_name, config_file):
+def _get_pes_args(config_file, h5file, individual_name):
     if "DLC" not in h5file or not h5file.endswith(".h5"):
         raise IOError("The file passed in is not a DeepLabCut h5 data file.")
 


### PR DESCRIPTION
The current method of dlc2nwb library: `convert_h5_to_nwb` does not allow:
- write subject specific information to only 1 nwbfile. It writes all subjects' (from the config file) into individual nwbfiles in a for loop.
- Does not have the option to write to an existing nwbfile. 

This PR adds a method `write_subject_to_nwb` that solves the 2 problems above. It also modularises the code a bit. 

I think this would be a good feature addition to the library: writing to an existing nwbfile is a common use case for users that write ephys/ophys data types to an nwbfile in addition to behavior DLC data. 

We are currently developing a tool ([nwbconversion](https://github.com/catalystneuro/nwb-conversion-tools/pull/414) tools) to write various data formats to nwb. With this added feature, we can leverage this library directly. 