### PR TITLE
Enable stand-alone conversion without DeepLabCut installed

### DIFF
--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -16,7 +16,7 @@ from ruamel.yaml import YAML
 try:
     from deeplabcut import __version__
     deeplabcut_version = __version__ 
-except:
+except ModuleNotFoundError:
     deeplabcut_version = None
 
 def read_config(configname):

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -65,8 +65,8 @@ def get_movie_timestamps(movie_file, VARIABILITYBOUND=1000):
     reader = cv2.VideoCapture(movie_file)
     timestamps = []
     for _ in range(len(reader)):
-        _ = reader.read_frame()
-        timestamps.append(reader.video.get(cv2.CAP_PROP_POS_MSEC))
+        _ = reader.read()
+        timestamps.append(reader.get(cv2.CAP_PROP_POS_MSEC))
 
     timestamps = np.array(timestamps) / 1000  # Convert to seconds
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    deeplabcut>=2.2.0.2
     ndx-pose
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     pynwb
     numpy
     pandas
+    tables
     opencv-python
     hdmf
     ruamel.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,14 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     ndx-pose
-
+    pynwb
+    numpy
+    pandas
+    opencv-python
+    hdmf
+    ruamel.yaml
+    pyyaml
 [options.extras_require]
-test = pytest
+test = 
+    pytest
+    deeplabcut>=2.2.0.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/DeepLabCut/DLC2NWB",
     install_requires=[
-        "deeplabcut>=2.2.0.5",
         "ndx-pose>=0.1.1",
     ],
     classifiers=(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 from dlc2nwb import utils
-
+import deeplabcut.utils 
 
 FILEPATH = "examples/m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
 CONFIGPATH = "examples/config.yaml"
@@ -31,3 +31,11 @@ def test_multi_animal_round_trip_conversion(tmp_path):
     df.to_hdf(path_fake_df, key="fake")
     nwbfiles = utils.convert_h5_to_nwb(CONFIGPATH, path_fake_df)
     assert len(nwbfiles) == n_animals
+
+
+def test_read_config_compability():
+    """This test ensures that the read_config function in this repo stays on synch with the one in deeplabcut"""    
+    config = utils.read_config(CONFIGPATH)
+    config_from_deep_lab_cut = deeplabcut.utils.auxiliaryfunctions.read_config(CONFIGPATH)
+    
+    assert config == config_from_deep_lab_cut


### PR DESCRIPTION
If accepted this should close  #14.

This PR modifies the code in such a way that the strict dependency on `deeplabcut` is eliminated. The biggest change is that it moves a small section of code from `deeplabcut` (the utility to read configuration files, `read_config`) into this repository. While this might lead to some code duplication in your ecosystem I believe that the benefits or having a less brittle installation pipeline are worth the cost. In order to mitigate this to some degree and avoid code drift I introduced another test which checks that the output of `read_config` here aligns with the same function on `deeplabcut`.

Other minor changes I discuss using the code review functionality as I think is easier to read that way.

Let me know if I am missing something. 