### PR TITLE
Infer missing timestamps

### DIFF
--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -37,6 +37,12 @@ def get_movie_timestamps(movie_file, VARIABILITYBOUND=1000):
             "Variability of timestamps suspiciously small. See: https://github.com/DeepLabCut/DLC2NWB/issues/1"
         )
 
+    if all(timestamps[-3:] == 0):
+        # Infers times when OpenCV bug provides 0s for last 3 frames
+        avg_frame_diff = np.mean(np.diff(timestamps[:-3])) # avg diff for usable frames
+        inferred_times = range(1, 4) * avg_frame_diff + timestamps[-4]
+        timestamps = np.concatenate((timestamps[:-3], inferred_times), axis=0)
+
     return timestamps
 
 
@@ -128,7 +134,7 @@ def _write_pes_to_nwbfile(nwbfile, animal, df_animal, scorer, video, paf_graph, 
         source_software="DeepLabCut",
         source_software_version=__version__,
         nodes=[pes.name for pes in pose_estimation_series],
-        edges=paf_graph,
+        edges=paf_graph if paf_graph else None,
     )
     if 'behavior' in nwbfile.processing:
         behavior_pm = nwbfile.processing["behavior"]

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -137,7 +137,9 @@ def _write_pes_to_nwbfile(nwbfile, animal, df_animal, scorer, video, paf_graph, 
         if exclude_nans: 
             # exclude_nans is inverse infer_timestamps. if not infer, there may be nans
             data = data[~np.isnan(timestamps)]
-            timestamps_cleaned = timestamps[~np.isnan(timestamps)]
+            timestamps_cleaned = timestamps[~np.isnan(timestamps)] 
+        else:
+            timestamps_cleaned = timestamps
 
         pes = PoseEstimationSeries(
             name=f"{animal}_{kpt}",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ def test_round_trip_conversion():
         FILEPATH,
     )[0]
     df = utils.convert_nwb_to_h5(nwbfile).droplevel("individuals", axis=1)
-    pd.testing.assert_frame_equal(df[:-3], df_ref[:-3])  # drop 3 OpenCV bug frames
+    pd.testing.assert_frame_equal(df, df_ref)
 
 
 def test_multi_animal_round_trip_conversion(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ def test_round_trip_conversion():
         FILEPATH,
     )[0]
     df = utils.convert_nwb_to_h5(nwbfile).droplevel("individuals", axis=1)
-    pd.testing.assert_frame_equal(df, df_ref)
+    pd.testing.assert_frame_equal(df[:-3], df_ref[:-3])  # drop 3 OpenCV bug frames
 
 
 def test_multi_animal_round_trip_conversion(tmp_path):


### PR DESCRIPTION
In some cases, OpenCV's `CAP_PROP_POS_MSEC` returns 0 for a subset of frames, often at the end. This can cause issues with some NWB interfaces. In this PR I ...

1. Add the ability to infer problematic timestamps.
2. Issue a warning with the percent of impacted timestamps.
3. Allow the user to select between inferring timestamps or dropping these data points. 
4. Revise skeleton saving to return `None` instead of an empty list, which also caused issues.

These edits have been reviewed and revised with members of of the CatalystNeuro team, @CodyCBakerPhD and @h-mayorquin, [here](https://github.com/catalystneuro/DLC2NWB/pull/1).