### PR TITLE
Use `opencv-python-headless` instead of full version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     numpy
     pandas
     tables
-    opencv-python
+    opencv-python-headless
     hdmf
     ruamel.yaml
     pyyaml


### PR DESCRIPTION
This should make the package a little bit ligther and less likely to cause problems with other dependencies.

From [the open-cv pipy](https://pypi.org/project/opencv-python/):

>  Packages for server (headless) environments (such as Docker, cloud environments etc.), no GUI library dependencies

> These packages are smaller than the two other packages above because they do not contain any GUI functionality (not compiled with Qt / other GUI components). This means that the packages avoid a heavy dependency chain to X11 libraries and you will have for example smaller Docker images as a result. You should always use these packages if you do not use cv2.imshow et al. or you are using some other package (such as PyQt) than OpenCV to create your GUI.

> Option 3 - Headless main modules package: `pip install opencv-python-headles`

