### PR TITLE
fix video len bug

### DIFF
--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -198,6 +198,7 @@ def _write_pes_to_nwbfile(
     paf_graph,
     timestamps,
     exclude_nans,
+    **optional_kwargs,
 ):  
     pose_estimation_series = []
     for kpt, xyp in df_animal.groupby(level="bodyparts", axis=1, sort=False):
@@ -233,6 +234,7 @@ def _write_pes_to_nwbfile(
         source_software_version=deeplabcut_version,
         nodes=[pes.name for pes in pose_estimation_series],
         edges=paf_graph if paf_graph else None,
+        **optional_kwargs,
     )
     if 'behavior' in nwbfile.processing:
         behavior_pm = nwbfile.processing["behavior"]

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -198,7 +198,7 @@ def _write_pes_to_nwbfile(
     paf_graph,
     timestamps,
     exclude_nans,
-    **optional_kwargs,
+    **pose_estimation_container_kwargs,
 ):  
     pose_estimation_series = []
     for kpt, xyp in df_animal.groupby(level="bodyparts", axis=1, sort=False):
@@ -234,7 +234,7 @@ def _write_pes_to_nwbfile(
         source_software_version=deeplabcut_version,
         nodes=[pes.name for pes in pose_estimation_series],
         edges=paf_graph if paf_graph else None,
-        **optional_kwargs,
+        **pose_estimation_container_kwargs,
     )
     if 'behavior' in nwbfile.processing:
         behavior_pm = nwbfile.processing["behavior"]

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -75,6 +75,7 @@ def get_movie_timestamps(movie_file, VARIABILITYBOUND=1000, infer_timestamps=Tru
     reader = cv2.VideoCapture(movie_file)
     timestamps = []
     n_frames = int(reader.get(cv2.CAP_PROP_FRAME_COUNT))
+    fps = reader.get(cv2.CAP_PROP_FPS)
 
     for _ in range(n_frames):
         _ = reader.read()
@@ -82,7 +83,7 @@ def get_movie_timestamps(movie_file, VARIABILITYBOUND=1000, infer_timestamps=Tru
 
     timestamps = np.array(timestamps) / 1000  # Convert to seconds
 
-    if np.nanvar(np.diff(timestamps)) < 1.0 / reader.fps * 1.0 / VARIABILITYBOUND:
+    if np.nanvar(np.diff(timestamps)) < 1.0 / fps * 1.0 / VARIABILITYBOUND:
         warnings.warn(
             "Variability of timestamps suspiciously small. See: https://github.com/DeepLabCut/DLC2NWB/issues/1"
         )

--- a/dlc2nwb/utils.py
+++ b/dlc2nwb/utils.py
@@ -74,7 +74,9 @@ def get_movie_timestamps(movie_file, VARIABILITYBOUND=1000, infer_timestamps=Tru
 
     reader = cv2.VideoCapture(movie_file)
     timestamps = []
-    for _ in range(len(reader)):
+    n_frames = int(reader.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    for _ in range(n_frames):
         _ = reader.read()
         timestamps.append(reader.get(cv2.CAP_PROP_POS_MSEC))
 


### PR DESCRIPTION
Fix issue raised in #22.

I've started the PR to make sure I'm not contributing code in the wrong place. I'm fixing some other issues arising as the result of relying on this library from `neuroconv` (eg, also `AttributeError: 'cv2.VideoCapture' object has no attribute 'fps', line 85`)